### PR TITLE
Move e2e tests into project repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+*.pyc
 
 # Folders
 _obj

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,97 @@
+# Bouncer Tests for download.allizom.org
+
+Thank you for checking out Mozilla's Bouncer test suite. Mozilla and [Web QA team](https://quality.mozilla.org/teams/web-qa/) are grateful for the help and hard work of many contributors [past](https://github.com/mozilla/bouncer-tests/graphs/contributors) and [present](https://github.com/mozilla-services/go-bouncer/graphs/contributors) like yourself.
+
+## Getting involved as a contributor
+
+We love working with contributors to fill out the test coverage for Bouncer Tests, but it does require a few skills. You will need to know some Python and you will need some basic familiarity with [GitHub](https://guides.github.com/).
+
+If you need to brush up on programming but are eager to start contributing immediately, please consider helping us [find bugs in Mozilla Firefox](https://oneanddone.mozilla.org/team/2/) or [find bugs in the Mozilla websites](https://oneanddone.mozilla.org/team/6/) tested by the Web QA team.
+
+To brush up on Python skills before engaging with us, [Dive Into Python](http://www.diveintopython.net/toc/) is an excellent resource. MIT also has [lecture notes on Python](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-189-a-gentle-introduction-to-programming-using-python-january-iap-2011/) available through their open courseware. The programming concepts you will need to know include functions, working with classes, and some object oriented programming basics.
+
+## Questions are always welcome
+
+While we take pains to keep our documentation updated, the best source of information is those of us who work on the project. Don't be afraid to join us in [irc.mozilla.org](https://wiki.mozilla.org/IRC) [#mozwebqa](http://chat.mibbit.com/?server=irc.mozilla.org&channel=#mozwebqa) to ask questions about Bouncer Tests. Mozilla also hosts the [#mozillians](http://chat.mibbit.com/?server=irc.mozilla.org&channel=#mozillians) chat room to answer your general questions about contributing to Mozilla.
+
+## How to set up and build Bouncer tests locally
+
+This repository contains tests suite used to test Mozilla's Bouncer. Mozilla maintains a guide to run automated tests on our [QMO website](https://quality.mozilla.org/docs/webqa/running-webqa-automated-tests/).
+
+You will need to install the following:
+
+* **Git**: If you have cloned this project already then you can skip this! GitHub has excellent guides for [Windows](https://help.github.com/articles/set-up-git/#platform-windows), [OS X](https://help.github.com/articles/set-up-git/#platform-mac) and [Linux](https://help.github.com/articles/set-up-git/#platform-linux).
+* **Python**: Before you will be able to run these tests you will need to have [Python 2.6](https://www.python.org/download/releases/2.6/) installed.
+
+### Installing `pip` (for managing Python packages)
+
+```bash
+sudo easy_install pip
+```
+
+### Installing dependencies
+
+If you are using `virtualenv`, run the following in the project root:
+
+```bash
+virtualenv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+If you are not using `virtualenv`, run the following in the project root to install dependencies globally:
+
+```bash
+sudo pip install -r requirements.txt
+```
+
+For more information on `virtualenv`, see below.
+
+### Running tests locally
+
+To run these tests, use:
+
+```bash
+py.test --baseurl="http://download.allizom.org" tests
+```
+
+Use `-k` to run a specific test. For example,
+
+```bash
+py.test -k test_that_checks_redirect_using_incorrect_query_values \
+        --baseurl="http://download.allizom.org" tests
+```
+
+The mozwebqa plugin has advanced command line options for reporting and using browsers. To see the options available, try running:
+
+```bash
+py.test --help
+```
+
+Also see the documentation on davehunt's [pytest-mozwebqa](https://github.com/davehunt/pytest-mozwebqa) GitHub project page.
+
+### `virtualenv` and `virtualenvwrapper` (optional, intermediate level)
+
+While most of us have had some experience using virtual machines, [`virtualenv`](https://pypi.python.org/pypi/virtualenv) is something else entirely. It's used to keep libraries that you install from clashing and messing up your local environment. After installing `virtualenv`, installing [`virtualenvwrapper`](https://bitbucket.org/dhellmann/virtualenvwrapper) will give you some nice commands to use with `virtualenv`.
+
+For a more detailed discussion of `virtualenv` and `virtualenvwrapper`, check out our [quick start guide](https://wiki.mozilla.org/QA/Execution/Web_Testing/Automation/Virtual_Environments) and also [this blog post](http://www.silverwareconsulting.com/index.cfm/2012/7/24/Getting-Started-with-virtualenv-and-virtualenvwrapper-in-Python).
+
+## Writing tests
+
+If you want to get involved and add more tests then there's just a few things we'd like to ask you to do:
+
+1. Use an existing file from this repository as a template for all new tests and page objects
+2. Follow our simple [style guide](https://wiki.mozilla.org/QA/Execution/Web_Testing/Docs/Automation/StyleGuide)
+3. Fork this project with your own GitHub account
+4. Add your test into the `tests` folder
+5. Make sure all tests are passing and submit a pull request with your changes
+
+## License
+
+This software is licensed under the MPL 2.0:
+
+```
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+```

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,136 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+LOCALES = (
+    'ach',
+    'af',
+    'an',
+    'ar',
+    'as',
+    'ast',
+    'be',
+    'bg',
+    'bn-BD',
+    'bn-IN',
+    'br',
+    'bs',
+    'ca',
+    'cs',
+    'csb',
+    'cy',
+    'da',
+    'de',
+    'el',
+    'en-GB',
+    'en-ZA',
+    'eo',
+    'es-AR',
+    'es-CL',
+    'es-ES',
+    'es-MX',
+    'et',
+    'eu',
+    'fa',
+    'ff',
+    'fi',
+    'fr',
+    'fy-NL',
+    'ga-IE',
+    'gd',
+    'gl',
+    'gu-IN',
+    'he',
+    'hi-IN',
+    'hr',
+    'hsb',
+    'hu',
+    'hy-AM',
+    'id',
+    'is',
+    'it',
+    'ja',
+    'kk',
+    'km',
+    'kn',
+    'ko',
+    'ku',
+    'lij',
+    'lt',
+    'lv',
+    'mai',
+    'mk',
+    'ml',
+    'mr',
+    'ms',
+    'nb-NO',
+    'nl',
+    'nn-NO',
+    'or',
+    'pa-IN',
+    'pl',
+    'pt-BR',
+    'pt-PT',
+    'rm',
+    'ro',
+    'ru',
+    'si',
+    'sk',
+    'sl',
+    'son',
+    'sq',
+    'sr',
+    'sv-SE',
+    'ta',
+    'te',
+    'th',
+    'tr',
+    'uk',
+    'vi',
+    'xh',
+    'zh-CN',
+    'zh-TW',
+    'zu'
+)
+
+OS = ('win', 'win64', 'linux', 'linux64', 'osx')
+
+
+def pytest_generate_tests(metafunc):
+    if 'lang' in metafunc.funcargnames:
+        metafunc.parametrize('lang', LOCALES)
+
+    if 'os' in metafunc.funcargnames:
+        metafunc.parametrize('os', OS)
+
+
+def pytest_configure(config):
+    if not config.option.base_url:
+        raise pytest.UsageError('--baseurl must be specified.')
+
+
+def pytest_addoption(parser):
+    parser.addoption('--baseurl',
+                     action='store',
+                     dest='base_url',
+                     metavar='url',
+                     help='base url for the application under test.')
+
+    parser.addoption('--product',
+                     action='store',
+                     dest='product',
+                     metavar='str',
+                     default='firefox-stub',
+                     help='product under test')
+
+
+@pytest.fixture
+def base_url(request):
+    return request.config.getoption("--baseurl")
+
+
+@pytest.fixture
+def product(request):
+    return request.config.getoption("--product")

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,3 @@
+pytest==2.7.3
+requests==2.7.0
+beautifulsoup4==4.0.4

--- a/tests/e2e/setup.cfg
+++ b/tests/e2e/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+ignore=E501
+
+[pytest]
+norecursedirs = venv

--- a/tests/e2e/tests/base.py
+++ b/tests/e2e/tests/base.py
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from urllib import urlencode
+
+import requests
+from bs4 import BeautifulSoup
+
+
+class Base:
+
+    _user_agent_firefox = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; '
+                           'rv:10.0.1) Gecko/20100101 Firefox/10.0.1')
+
+    def _head_request(self, url, user_agent=_user_agent_firefox,
+                      locale='en-US', params=None):
+        headers = {'user-agent': user_agent,
+                   'accept-language': locale,
+                   'Connection': 'close'}
+
+        try:
+            r = requests.head(url, headers=headers, verify=False, timeout=15,
+                              params=params, allow_redirects=False)
+        except requests.RequestException as e:
+            request_url = self._build_request_url(url, params)
+
+            raise AssertionError('Failing URL: %s.\nError message: %s' % (request_url, e))
+
+        if r.status_code == 302 and r.headers['Location']:
+            try:
+                request_url = r.headers['Location']
+                r = requests.head(request_url, headers=headers, verify=False,
+                                  timeout=15, allow_redirects=True)
+            except requests.RequestException as e:
+                raise AssertionError('Failing URL: %s.\nError message: %s' % (request_url, e))
+
+        return r
+
+    def _parse_response(self, content):
+        return BeautifulSoup(content)
+
+    def response_info_failure_message(self, url, param, response):
+        return 'Failed on %s \nUsing %s.\n %s' % (url,
+                                                  param,
+                                                  self.response_info(response))
+
+    def response_info(self, response):
+        url = response.url
+        return 'Response URL: %s\n Response Headers:\n %s' \
+               % (url, self.get_headers(response))
+
+    def get_x_backend_server(self, response):
+        return response.headers.get('X-Backend-Server') or 'Unknown'
+
+    def get_headers(self, response):
+        return '\n'.join(['%s: %s' % (header, value) for header, value in response.headers.items()])
+
+    def _build_request_url(self, url, params):
+        if params:
+            return '%s/?%s' % (url, urlencode(params))
+        else:
+            return url

--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -1,0 +1,207 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+import requests
+from urlparse import urlparse
+from urllib import urlencode
+
+from base import Base
+
+
+class TestRedirects(Base):
+
+    _winxp_products = [
+        '38.5.1esr',
+        '38.5.2esr',
+        '38.5.3esr',
+        '38.6.3esr',
+        '40.0.0esr',
+        'stub',
+        'latest',
+        '42.0',
+        '43.0.1',
+        '44.0',
+        'beta-latest',
+        'beta',
+        '44.0b1'
+    ]
+
+    @pytest.mark.parametrize(('product_alias'), _winxp_products)
+    def test_ie6_winxp_useragent_5_1_redirects_to_correct_version(self, base_url, product_alias):
+        # With Bug 1233779, WinXP bouncer is configured to redirect users
+        # to Firefox version 43.0.1 if they visit firefox-latest and firefox-44.0
+        user_agent_ie6 = ('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')
+
+        self._verify_winxp_redirect_rules(base_url, product_alias, user_agent_ie6)
+
+    @pytest.mark.parametrize(('product_alias'), _winxp_products)
+    def test_ie6_winxp_useragent_5_2_redirects_to_correct_version(self, base_url, product_alias):
+        # With Bug 1233779, WinXP bouncer is configured to redirect users
+        # to Firefox version 43.0.1 if they visit firefox-latest and firefox-44.0
+        user_agent_ie6 = ('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; SV1)')
+
+        self._verify_winxp_redirect_rules(base_url, product_alias, user_agent_ie6)
+
+    def _verify_winxp_redirect_rules(self, base_url, product_alias, user_agent,):
+        param = {
+            'product': 'firefox-' + product_alias,
+            'lang': 'en-US',
+            'os': 'win'
+        }
+        response = self._head_request(base_url, user_agent=user_agent, params=param)
+        parsed_url = urlparse(response.url)
+        if product_alias in ['stub', 'latest', '44.0', '43.0.1']:
+            assert '43.0.1.exe' in parsed_url.path
+        elif 'esr' in product_alias:
+            assert '38.5.1esr.exe' in parsed_url.path
+        elif product_alias in ['beta-latest', 'beta', '44.0b1']:
+            assert '44.0b1.exe' in parsed_url.path
+        else:
+            assert (product_alias + '.exe') in parsed_url.path
+
+    def test_ie6_vista_6_0_redirects_to_correct_version(self, base_url):
+        user_agent = ('Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 6.0; SV1; .NET CLR 2.0.50727)')
+        param = {
+            'product': 'firefox-stub',
+            'lang': 'en-US',
+            'os': 'win'
+        }
+        response = self._head_request(base_url, user_agent=user_agent, params=param)
+        parsed_url = urlparse(response.url)
+        assert '43.0.1.exe' in parsed_url.path
+
+    def test_that_checks_redirect_using_incorrect_query_values(self, base_url):
+        param = {
+            'product': 'firefox-31.0',
+            'lang': 'kitty_language',
+            'os': 'stella'
+        }
+        response = self._head_request(base_url, params=param)
+
+        assert (requests.codes.not_found == response.status_code,
+                self.response_info_failure_message(base_url, param, response))
+
+        parsed_url = urlparse(response.url)
+
+        assert ('http' == parsed_url.scheme, 'Failed to redirect to the correct scheme. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+        assert (urlparse(base_url).netloc == parsed_url.netloc,
+                self.response_info_failure_message(base_url, param, response))
+
+        assert (urlencode(param) == parsed_url.query,
+                self.response_info_failure_message(base_url, param, response))
+
+        assert ('Unknown' != self.get_x_backend_server(response),
+                'Failed, x-backend-server was not in the response object. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+    def test_that_checks_redirect_using_locales_and_os(
+        self,
+        base_url,
+        lang,
+        os
+    ):
+        # Ja locale has a special code for mac
+        if lang == 'ja' and os == 'osx':
+            lang = 'ja-JP-mac'
+
+        param = {
+            'product': 'firefox-31.0',
+            'lang': lang,
+            'os': os
+        }
+
+        response = self._head_request(base_url, params=param)
+
+        parsed_url = urlparse(response.url)
+
+        assert (requests.codes.ok == response.status_code,
+                'Redirect failed with HTTP status. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+        assert ('http' == parsed_url.scheme, 'Failed to redirect to the correct scheme. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+        assert ('Unknown' != self.get_x_backend_server(response),
+                'Failed, x-backend-server was not in the response object %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+    def test_stub_installer_redirect_for_en_us_and_win(self, base_url, product):
+        param = {
+            'product': product,
+            'lang': 'en-US',
+            'os': 'win'
+        }
+
+        response = self._head_request(base_url, params=param)
+
+        parsed_url = urlparse(response.url)
+
+        assert (requests.codes.ok == response.status_code,
+                'Redirect failed with HTTP status. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+        assert ('https' == parsed_url.scheme,
+                'Failed to redirect to the correct scheme. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+        assert ('download-installer.cdn.mozilla.net' == parsed_url.netloc,
+                'Failed by redirected to incorrect host. %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+        assert ('Unknown' != self.get_x_backend_server(response),
+                'Failed, x-backend-server was not in the response object %s' %
+                self.response_info_failure_message(base_url, param, response))
+
+    @pytest.mark.parametrize('product_alias', [
+        {'product_name': 'firefox-beta-latest', 'lang': 'en-US'},
+        {'product_name': 'firefox-latest-euballot', 'lang': 'en-GB'},
+        {'product_name': 'firefox-latest', 'lang': 'en-US'},
+        {'product_name': 'firefox-beta-stub', 'lang': 'en-US'},
+        {'product_name': 'firefox-nightly-latest', 'lang': 'en-US'},
+    ])
+    def test_redirect_for_firefox_aliases(self, base_url, product_alias):
+        param = {
+            'product': product_alias['product_name'],
+            'os': 'win',
+            'lang': product_alias['lang']
+        }
+
+        response = self._head_request(base_url, params=param)
+
+        parsed_url = urlparse(response.url)
+
+        if not (
+            product_alias['product_name'] == 'firefox-latest-euballot' and
+            "download.allizom.org" in base_url
+        ):
+            url_scheme = 'http'
+            if product_alias['product_name'] == 'firefox-beta-stub':
+                url_scheme = 'https'
+
+            assert (requests.codes.ok == response.status_code,
+                    'Redirect failed with HTTP status. %s' %
+                    self.response_info_failure_message(base_url, param, response))
+
+            assert (url_scheme == parsed_url.scheme,
+                    'Failed to redirect to the correct scheme. %s' %
+                    self.response_info_failure_message(base_url, param, response))
+
+            assert (parsed_url.netloc in ['download.cdn.mozilla.net', 'edgecastcdn.net',
+                    'download-installer.cdn.mozilla.net', 'cloudfront.net', 'ftp.mozilla.org'],
+                    'Failed, redirected to unknown host. %s' %
+                    self.response_info_failure_message(base_url, param, response))
+
+            assert ('Unknown' != self.get_x_backend_server(response),
+                    'Failed, x-backend-server was not in the response object %s' %
+                    self.response_info_failure_message(base_url, param, response))
+
+            if (
+                product_alias['product_name'] != 'firefox-nightly-latest' and
+                product_alias['product_name'] != 'firefox-aurora-latest' and
+                product_alias['product_name'] != 'firefox-latest-euballot'
+            ):
+                assert '/win32/' in parsed_url.path, self.response_info(response)


### PR DESCRIPTION
Consolidate QA's end-to-end tests into the go-bouncer project repository and decommission [bouncer-tests](https://github.com/mozilla/bouncer-tests/). 