### PR TITLE
bump requests to 2.11.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest==2.9.2
     pytest-base-url==1.1.0
     pytest-xdist==1.14
-    requests==2.10.0
+    requests==2.11.0
 commands = py.test {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
Bump `requests` to the latest version. Used by our e2e tests.

r? @stephendonner + @mozilla/web-qa-sorcerers