### PR TITLE
Quell pytest warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 ignore=E501
 
-[pytest]
+[tool:pytest]
 addopts=-n=auto --verbose -r=a
 testpaths=tests/e2e
 xfail_strict=true


### PR DESCRIPTION
Quiets "13:45:32 WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead."

@m8ttyB r?