### PR TITLE
update winxp checks

### DIFF
--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -146,7 +146,7 @@ class TestRedirects(Base):
         response = self._head_request(base_url, user_agent=user_agent, params=param)
         parsed_url = urlparse(response.url)
         if product_alias in ['stub', 'latest', '42.0', '43.0.1', '44.0']:
-            assert '43.0.1.exe' in parsed_url.path
+            assert '49.0.exe' in parsed_url.path
         elif 'esr' in product_alias:
             assert '38.5.1esr.exe' in parsed_url.path
         elif product_alias in ['49.0b8', '49.0b10', '49.0b37']:
@@ -160,9 +160,9 @@ class TestRedirects(Base):
             extracted_ver_num = parsed_url.path.split('Firefox%20Setup%20')[1].split('.')[0]
             assert 49 <= int(extracted_ver_num)
         elif product_alias in ['beta']:
-            assert '43.0.1.exe' in parsed_url.path
+            assert '49.0.exe' in parsed_url.path
         else:
-            assert ('43.0.1.exe') in parsed_url.path
+            assert '49.0.exe' in parsed_url.path
 
     def test_ie6_vista_6_0_redirects_to_correct_version(self, base_url):
         user_agent = ('Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 6.0; SV1; .NET CLR 2.0.50727)')


### PR DESCRIPTION
This is the real deal 👍 

A new set of rules landed for the winxp builds, they're now on the release channel. 
* Changes currently reflect the behavior of production.
* Tests will fail when run against stage until [bug 1304116](https://bugzilla.mozilla.org/show_bug.cgi?id=1304116) is resolved.
* A plan to have prod and stage sync'd in a more timely manner is in the works.

r? @stephendonner 