### PR TITLE
bug: update to requests[security]

### DIFF
--- a/tests/e2e/requirements/tests.txt
+++ b/tests/e2e/requirements/tests.txt
@@ -2,4 +2,4 @@ beautifulsoup4==4.5.3
 pytest==3.0.6
 pytest-base-url==1.2.0
 pytest-xdist==1.15.0
-requests==2.13.0
+requests[security]==2.13.0


### PR DESCRIPTION
So this is potentially interesting, my current best guess is that when `requests` was bumped to `2.13` in pr #77 this manifested. I'm also not sure how we missed this during the review process.

`request==2.13.0` changes the behavior of the library by not loading `idna` unless it is determined to be needed ([release notes](https://pypi.python.org/pypi/requests/).

By explicitly installing the security package, `requests[security]==2.13.0`, we force 3 additional packages to be installed, which allow for "better" SSL handling [[0](http://stackoverflow.com/questions/31811949/pip-install-requestssecurity-vs-pip-install-requests-difference)].
* pyOpenSSL
* cryptography
* idna

Successful run:
[http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/bouncer.adhoc/39/](http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/bouncer.adhoc/39/)

r? @stephendonner & @oremj 