### PR TITLE
Pass 'xterm' in to ansiColor()

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -3,7 +3,7 @@
 pipeline {
   agent any
   options {
-    ansiColor()
+    ansiColor('xterm')
     timestamps()
     timeout(time: 5, unit: 'MINUTES')
   }


### PR DESCRIPTION
Due to Pipeline Model Definition changes

@davehunt @oremj r?