### PR TITLE
temporarily disable email notifications

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -30,14 +30,14 @@ pipeline {
     }
   }
   post {
-    failure {
+    /* failure {
       mail(
         body: "${BUILD_URL}",
         from: "firefox-test-engineering@mozilla.com",
         replyTo: "firefox-test-engineering@mozilla.com",
         subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
         to: "fte-ci@mozilla.com")
-    }
+    } */
     changed {
       ircNotification()
     }


### PR DESCRIPTION
Until the esr builds are straightened out we will receive failure emails. Temporarily disabling email notifications.