### PR TITLE
update utils to use the FIREFOX_ESR_NEXT key

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -30,14 +30,14 @@ pipeline {
     }
   }
   post {
-    /* failure {
+    failure {
       mail(
         body: "${BUILD_URL}",
         from: "firefox-test-engineering@mozilla.com",
         replyTo: "firefox-test-engineering@mozilla.com",
         subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
         to: "fte-ci@mozilla.com")
-    } */
+    }
     changed {
       ircNotification()
     }

--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -130,7 +130,7 @@ class TestRedirects(Base):
             'os': 'win'
         }
         response = self._head_request(base_url, user_agent=user_agent_ie6, params=param)
-        assert '52.0esr.exe' in response.url, param
+        assert '52.0.1esr.exe' in response.url, param
 
     @pytest.mark.parametrize(('product_alias'), _winxp_products)
     def test_ie6_winxp_useragent_5_2_redirects_to_correct_version(self, base_url, product_alias):
@@ -141,7 +141,7 @@ class TestRedirects(Base):
             'os': 'win'
         }
         response = self._head_request(base_url, user_agent=user_agent_ie6, params=param)
-        assert '52.0esr.exe' in response.url, param
+        assert '52.0.1esr.exe' in response.url, param
 
     def _extract_windows_version_num(self, path):
         return int(path.split('Firefox%20Setup%20')[1].split('.')[0])

--- a/tests/e2e/tests/utils.py
+++ b/tests/e2e/tests/utils.py
@@ -12,9 +12,9 @@ class RelengHelper:
     # mappings adapted off of https://github.com/mozilla-releng/ship-it/blob/master/kickoff/config.py
     releng_to_bouncer_alias_dict = {
         'FIREFOX_AURORA': 'firefox-aurora-latest',
-        'FIREFOX_ESR_NEXT': None,  # no checks to run on this product
+        'FIREFOX_ESR_NEXT': 'firefox-esr-latest',
         'LATEST_FIREFOX_VERSION': 'firefox-latest',
-        'FIREFOX_ESR': 'firefox-esr-latest',
+        'FIREFOX_ESR': None,  # no checks to run on this product
         'FIREFOX_NIGHTLY': 'firefox-nightly-latest',
         'LATEST_FIREFOX_OLDER_VERSION': None,  # no checks to run on this product
         'LATEST_FIREFOX_RELEASED_DEVEL_VERSION': 'firefox-beta-latest',


### PR DESCRIPTION
Several things conspired to add confusion, but the tests ultimately did the right thing; caught errors and helped QA have clarifying conversations with releng.

Tests were effected by issues that arose during the initial ESR release, followed by the subsequent dot release. Most recently pr #93 hit an issue where [bug 1350468](https://bugzilla.mozilla.org/show_bug.cgi?id=1350468) was discovered, this has since been fixed.

* update IE6 esr version to recent dot release - `52.0.1esr`
* Update alias tests to use`'FIREFOX_ESR_NEXT': 'firefox-esr-latest'`
* re-enable email notifications