### PR TITLE
update ie6 tests to reflect new build, xfail where appropriate

### DIFF
--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -16,11 +16,11 @@ class TestRedirects(Base):
     _locales = utils.get_firefox_locales()
     _os = ('win', 'win64', 'linux', 'linux64', 'osx')
     _winxp_products = [
-        '38.5.1esr',
-        '38.5.2esr',
-        '38.5.3esr',
-        '38.6.3esr',
-        '40.0.0esr',
+        pytest.mark.xfail(reason='bug 1351900')('38.5.1esr'),
+        pytest.mark.xfail(reason='bug 1351900')('38.5.2esr'),
+        pytest.mark.xfail(reason='bug 1351900')('38.5.3esr'),
+        pytest.mark.xfail(reason='bug 1351900')('38.6.3esr'),
+        pytest.mark.xfail(reason='bug 1351900')('40.0.0esr'),
         'stub',
         'latest',
         'sha1',
@@ -28,10 +28,10 @@ class TestRedirects(Base):
         '43.0.1',
         '44.0',
         'beta',
-        'beta-latest',
-        '49.0b8',
-        '49.0b10',
-        '49.0b37'
+        pytest.mark.xfail(reason='bug 1351900')('beta-latest'),
+        pytest.mark.xfail(reason='bug 1351900')('49.0b8'),
+        pytest.mark.xfail(reason='bug 1351900')('49.0b10'),
+        pytest.mark.xfail(reason='bug 1351900')('49.0b37')
     ]
 
     @pytest.mark.parametrize(('product_alias'), _winxp_products)
@@ -43,7 +43,7 @@ class TestRedirects(Base):
             'os': 'win'
         }
         response = self.request_with_headers(base_url, user_agent=user_agent_ie6, params=param)
-        assert '52.0.1esr.exe' in response.url, param
+        assert '52.0.2esr.exe' in response.url, param
 
     @pytest.mark.parametrize(('product_alias'), _winxp_products)
     def test_ie6_winxp_useragent_5_2_redirects_to_correct_version(self, base_url, product_alias):
@@ -54,7 +54,7 @@ class TestRedirects(Base):
             'os': 'win'
         }
         response = self.request_with_headers(base_url, user_agent=user_agent_ie6, params=param)
-        assert '52.0.1esr.exe' in response.url, param
+        assert '52.0.2esr.exe' in response.url, param
 
     def _extract_windows_version_num(self, path):
         return int(path.split('Firefox%20Setup%20')[1].split('.')[0])


### PR DESCRIPTION
This pr updates the IE6 tests to point to the `52.0.2esr.exe` build. It also xfails the aliases that are incorrectly redirecting to `52.0.1esr`.

Closes #100 

> tox -- -k ie
py27 installed: apipkg==1.4,appdirs==1.4.3,asn1crypto==0.22.0,beautifulsoup4==4.5.3,blessings==1.6,cffi==1.10.0,cryptography==1.8.1,enum34==1.1.6,execnet==1.4.1,idna==2.5,ipaddress==1.0.18,mozlog==3.4,packaging==16.8,py==1.4.33,pycparser==2.17,pyOpenSSL==16.2.0,pyparsing==2.2.0,pytest==3.0.7,pytest-base-url==1.3.0,pytest-metadata==1.3.0,pytest-xdist==1.15.0,requests==2.13.0,six==1.10.0
py27 runtests: PYTHONHASHSEED='1188635590'
py27 runtests: commands[0] | pytest --junit-xml=results/py27.xml --log-raw=results/py27.log -k ie
============================= test session starts ==============================
platform darwin -- Python 2.7.13, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /Users/admin/workspaces/go-bouncer/tests/e2e/.tox/py27/bin/python2.7
cachedir: .cache
metadata: {'Packages': {'pluggy': '0.4.0', 'pytest': '3.0.7', 'py': '1.4.33'}, 'Python': '2.7.13', 'Plugins': {'mozlog': '3.4', 'xdist': '1.15.0', 'base-url': '1.3.0', 'metadata': '1.3.0'}, 'Base URL': 'http://bouncer-bouncer.stage.mozaws.net', 'Platform': 'Darwin-16.4.0-x86_64-i386-64bit'}
baseurl: http://bouncer-bouncer.stage.mozaws.net
rootdir: /Users/admin/workspaces/go-bouncer/tests/e2e, inifile: tox.ini
plugins: xdist-1.15.0, metadata-1.3.0, base-url-1.3.0, mozlog-3.4
collecting ... collected 528 items

tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.1esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.2esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.3esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.6.3esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[40.0.0esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[sha1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[42.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[43.0.1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[44.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-latest] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b8] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b10] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b37] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.1esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.2esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.3esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.6.3esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[40.0.0esr] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[sha1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[42.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[43.0.1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[44.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-latest] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b8] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b10] xfail
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b37] xfail

 generated xml file: /Users/admin/workspaces/go-bouncer/tests/e2e/results/py27.xml 
=========================== short test summary info ============================
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.1esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.2esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.3esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.6.3esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[40.0.0esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-latest]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b8]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b10]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b37]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.1esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.2esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.3esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.6.3esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[40.0.0esr]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-latest]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b8]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b10]
  bug 1351900
XFAIL tests/test_redirects.py::TestRedirects::()::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b37]
  bug 1351900
============================= 496 tests deselected =============================
============ 14 passed, 496 deselected, 18 xfailed in 29.83 seconds ============
flake8 installed: appdirs==1.4.3,configparser==3.5.0,enum34==1.1.6,flake8==3.3.0,mccabe==0.6.1,packaging==16.8,pycodestyle==2.3.1,pyflakes==1.5.0,pyparsing==2.2.0,six==1.10.0
flake8 runtests: PYTHONHASHSEED='1188635590'
flake8 runtests: commands[0] | flake8 -k ie
ERROR: InvocationError: '/Users/admin/workspaces/go-bouncer/tests/e2e/.tox/flake8/bin/flake8 -k ie'
___________________________________ summary ____________________________________
  py27: commands succeeded
ERROR:   flake8: commands failed