### PR TITLE
xfail tests when run against stage

### DIFF
--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -16,11 +16,11 @@ class TestRedirects(Base):
     _locales = utils.get_firefox_locales()
     _os = ('win', 'win64', 'linux', 'linux64', 'osx')
     _winxp_products = [
-        pytest.mark.xfail(reason='bug 1351900')('38.5.1esr'),
-        pytest.mark.xfail(reason='bug 1351900')('38.5.2esr'),
-        pytest.mark.xfail(reason='bug 1351900')('38.5.3esr'),
-        pytest.mark.xfail(reason='bug 1351900')('38.6.3esr'),
-        pytest.mark.xfail(reason='bug 1351900')('40.0.0esr'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('38.5.1esr'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('38.5.2esr'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('38.5.3esr'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('38.6.3esr'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('40.0.0esr'),
         'stub',
         'latest',
         'sha1',
@@ -28,10 +28,10 @@ class TestRedirects(Base):
         '43.0.1',
         '44.0',
         'beta',
-        pytest.mark.xfail(reason='bug 1351900')('beta-latest'),
-        pytest.mark.xfail(reason='bug 1351900')('49.0b8'),
-        pytest.mark.xfail(reason='bug 1351900')('49.0b10'),
-        pytest.mark.xfail(reason='bug 1351900')('49.0b37')
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('beta-latest'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('49.0b8'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('49.0b10'),
+        pytest.mark.xfail("'stage' in config.getvalue('base_url')", reason='bug 1351900')('49.0b37')
     ]
 
     @pytest.mark.parametrize(('product_alias'), _winxp_products)


### PR DESCRIPTION
Closes #100 

This pr target's the parametized xfails to only occur when run against stage.
Targets [bug 1351900](https://bugzilla.mozilla.org/show_bug.cgi?id=1351900)

/cc @rail 

`tox -- -n 4 -k ie` 
stage run - https://gist.github.com/m8ttyB/f0edbacf55f3dd76985b6b64926d2692
prod run - https://gist.github.com/m8ttyB/dcbbcbe5e929ebea4984de64ac3607bc