### PR TITLE
remove ie6 xfails from e2e tests

### DIFF
--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -16,11 +16,11 @@ class TestRedirects(Base):
     _locales = utils.get_firefox_locales()
     _os = ('win', 'win64', 'linux', 'linux64', 'osx')
     _winxp_products = [
-        pytest.mark.xfail(reason='bug 1351900')('38.5.1esr'),
-        pytest.mark.xfail(reason='bug 1351900')('38.5.2esr'),
-        pytest.mark.xfail(reason='bug 1351900')('38.5.3esr'),
-        pytest.mark.xfail(reason='bug 1351900')('38.6.3esr'),
-        pytest.mark.xfail(reason='bug 1351900')('40.0.0esr'),
+        '38.5.1esr',
+        '38.5.2esr',
+        '38.5.3esr',
+        '38.6.3esr',
+        '40.0.0esr',
         'stub',
         'latest',
         'sha1',
@@ -28,10 +28,10 @@ class TestRedirects(Base):
         '43.0.1',
         '44.0',
         'beta',
-        pytest.mark.xfail(reason='bug 1351900')('beta-latest'),
-        pytest.mark.xfail(reason='bug 1351900')('49.0b8'),
-        pytest.mark.xfail(reason='bug 1351900')('49.0b10'),
-        pytest.mark.xfail(reason='bug 1351900')('49.0b37')
+        'beta-latest',
+        '49.0b8',
+        '49.0b10',
+        '49.0b37'
     ]
 
     @pytest.mark.parametrize(('product_alias'), _winxp_products)


### PR DESCRIPTION
Closes #103 

Remove xfails now that tests are passing.

prod run -`tox -- -n 4 --base-url=http://download.mozilla.org -k ie`
* https://gist.github.com/m8ttyB/c551a94ee845c5a3d942bf05a2aac2d5

stage run -`tox -- -n 4 -k ie`
* https://gist.github.com/m8ttyB/45aac6a55f1d8c0ce0e7b2fd44d04ffb