### PR TITLE
Submit to Treeherder; bump shared-library version

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
           archiveArtifacts 'tests/e2e/results/*'
           junit 'tests/e2e/results/*.xml'
           submitToActiveData('tests/e2e/results/py27_raw.txt')
-          submitToTreeherder('go-bouncer', 'T', 'Tests', 'tests/e2e/results/py27_tbpl.txt')
+          submitToTreeherder('go-bouncer', 'T', 'Tests', 'tests/e2e/results/*', 'tests/e2e/results/py27_tbpl.txt')
         }
       }
     }

--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@1.3') _
+@Library('fxtest@1.6') _
 
 pipeline {
   agent any
@@ -9,6 +9,7 @@ pipeline {
   }
   environment {
     PYTEST_ADDOPTS = "-n=10 --color=yes"
+    PULSE = credentials('PULSE')
   }
   stages {
     stage('Lint') {
@@ -24,7 +25,8 @@ pipeline {
         always {
           archiveArtifacts 'tests/e2e/results/*'
           junit 'tests/e2e/results/*.xml'
-          submitToActiveData('tests/e2e/results/py27.log')
+          submitToActiveData('tests/e2e/results/py27_raw.txt')
+          submitToTreeherder('bouncer-tests', 'T', 'Tests', 'tests/e2e/results/py27_tbpl.txt')
         }
       }
     }

--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
           archiveArtifacts 'tests/e2e/results/*'
           junit 'tests/e2e/results/*.xml'
           submitToActiveData('tests/e2e/results/py27_raw.txt')
-          submitToTreeherder('bouncer-tests', 'T', 'Tests', 'tests/e2e/results/py27_tbpl.txt')
+          submitToTreeherder('go-bouncer', 'T', 'Tests', 'tests/e2e/results/py27_tbpl.txt')
         }
       }
     }

--- a/tests/e2e/tox.ini
+++ b/tests/e2e/tox.ini
@@ -7,7 +7,7 @@ passenv = PYTEST_ADDOPTS PYTEST_BASE_URL JENKINS_URL JOB_NAME BUILD_NUMBER
 deps = -rrequirements/tests.txt
 commands = pytest \
   --junit-xml=results/{envname}.xml \
-  --log-raw=results/{envname}_raw.txt \
+  --log-raw=results/{envname}.txt \
   --log-tbpl=results/{envname}_tbpl.txt \
   {posargs}
 

--- a/tests/e2e/tox.ini
+++ b/tests/e2e/tox.ini
@@ -7,7 +7,7 @@ passenv = PYTEST_ADDOPTS PYTEST_BASE_URL JENKINS_URL JOB_NAME BUILD_NUMBER
 deps = -rrequirements/tests.txt
 commands = pytest \
   --junit-xml=results/{envname}.xml \
-  --log-raw=results/{envname}.txt \
+  --log-raw=results/{envname}_raw.txt \
   --log-tbpl=results/{envname}_tbpl.txt \
   {posargs}
 

--- a/tests/e2e/tox.ini
+++ b/tests/e2e/tox.ini
@@ -7,7 +7,8 @@ passenv = PYTEST_ADDOPTS PYTEST_BASE_URL JENKINS_URL JOB_NAME BUILD_NUMBER
 deps = -rrequirements/tests.txt
 commands = pytest \
   --junit-xml=results/{envname}.xml \
-  --log-raw=results/{envname}.log \
+  --log-raw=results/{envname}_raw.txt \
+  --log-tbpl=results/{envname}_tbpl.txt \
   {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
@davehunt / @m8ttyB / @oremj r?

Ad-hoc run here: https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/bouncer.adhoc/18/console

For the full log: https://gist.github.com/stephendonner/1c135b945f2d380b0e9c277c26b078bd

Background blog post: http://davehunt.co.uk/2017/04/10/reporting-test-results-to-treeherder.html