### PR TITLE
update winxp tests to use product-details + update xp tests

### DIFF
--- a/tests/e2e/tests/releng_utils.py
+++ b/tests/e2e/tests/releng_utils.py
@@ -103,7 +103,7 @@ def get_version_info_for_alias(alias, base_url=_product_details_url):
     :param base_url: The url of the service that hosts the product details.
     :return String: The version number of Firefox
     """
-    products = get_product_mappings()
+    products = get_product_mappings(base_url)
     return products[alias]
 
 

--- a/tests/e2e/tests/releng_utils.py
+++ b/tests/e2e/tests/releng_utils.py
@@ -93,6 +93,20 @@ def fetch_current_fx_product_details(base_url=_product_details_url):
     return releng_products
 
 
+def get_version_info_for_alias(alias, base_url=_product_details_url):
+    """Using up-to-date information drawn from product details service, find the current version of
+    a Firefox product.
+
+    releng_to_bouncer_alias_dict lists the available aliases.
+
+    :param alias: The go-bouncer alias to get the version of. For example, 'firefox-latest'
+    :param base_url: The url of the service that hosts the product details.
+    :return String: The version number of Firefox
+    """
+    products = get_product_mappings()
+    return products[alias]
+
+
 def get_firefox_locales():
     """Fetches build versions for each localization of Firefox from Mozilla's Release
     Engineering Team.
@@ -111,3 +125,15 @@ def get_firefox_locales():
         versions = locale_data[locale]
         locale_objs.append(FirefoxLocale(locale, versions))
     return locale_objs
+
+
+def get_product_mappings(base_url=_product_details_url):
+    """Get a current list of product details, primary Firefox aliases and the
+    current version numbers.
+    The default url that product information is pulled from is https://product-details.mozilla.org/1.0/firefox_versions.json
+
+    :param base_url: The url of the service that hosts the product details.
+    :return dictionary: Product aliases and version numbers
+    """
+    releng_aliases = fetch_current_fx_product_details(base_url)
+    return generate_fx_alias_ver_mappings(releng_aliases)

--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -15,24 +15,27 @@ class TestRedirects(Base):
 
     _locales = utils.get_firefox_locales()
     _os = ('win', 'win64', 'linux', 'linux64', 'osx')
-    _winxp_esr_version = '52.1.0esr.exe'
+    _winxp_esr_version = utils.get_version_info_for_alias('firefox-esr-latest')
     _winxp_products = [
-        '38.5.1esr',
-        '38.5.2esr',
-        '38.5.3esr',
-        '38.6.3esr',
-        '40.0.0esr',
         'stub',
         'latest',
         'sha1',
-        '42.0',
-        '43.0.1',
-        '44.0',
+        'esr-latest',
+        'esr-sha1',
+        'esr-stub',
         'beta',
         'beta-latest',
+        'beta-sha',
+        'beta-stub',
+        '38.5.1esr',
+        '40.0.0esr',
+        '58.0.0esr',
+        '42.0',
+        '43.0.1',
         '49.0b8',
-        '49.0b10',
-        '49.0b37'
+        '49.0b8-ssl',
+        '100.0',
+        'cats'
     ]
 
     @pytest.mark.parametrize(('product_alias'), _winxp_products)


### PR DESCRIPTION
Update to the winxp tests. closes #119 

- [x] Tests now pull from `product-details` to identify the expected Firefox esr build version.
- [x] Refresh the winxp test to use an up-to-date list of product aliases.

Test runs using `tox -- -k winxp`:
* Prod run - https://gist.github.com/be8d3cf252ac57d2031878bfc7cee789
* State run - https://gist.github.com/4789ec270d526437b7c025f34e265bf4