### PR TITLE
remove firefox-esr-sha1 winxp checks

### DIFF
--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -21,7 +21,6 @@ class TestRedirects(Base):
         'latest',
         'sha1',
         'esr-latest',
-        'esr-sha1',
         'esr-stub',
         'beta',
         'beta-latest',


### PR DESCRIPTION
Closes #122 

Test results when run against prod & stage:

```e2e git:(issue-122) ✗ tox -- --base-url=https://download.mozilla.org -k winxp
py27 installed: apipkg==1.4,appdirs==1.4.3,asn1crypto==0.22.0,blessings==1.6,cffi==1.10.0,cryptography==1.8.1,enum34==1.1.6,execnet==1.4.1,idna==2.5,ipaddress==1.0.18,mozlog==3.4,packaging==16.8,py==1.4.33,pycparser==2.17,pyOpenSSL==16.2.0,pyparsing==2.2.0,pytest==3.0.7,pytest-base-url==1.3.0,pytest-metadata==1.3.0,pytest-xdist==1.15.0,requests==2.13.0,six==1.10.0
py27 runtests: PYTHONHASHSEED='3937497833'
py27 runtests: commands[0] | pytest --junit-xml=results/py27.xml --log-raw=results/py27_raw.txt --log-tbpl=results/py27_tbpl.txt --base-url=https://download.mozilla.org -k winxp
================================================================ test session starts ================================================================
platform darwin -- Python 2.7.10, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /Users/mbrandt/workspaces/go-bouncer/tests/e2e/.tox/py27/bin/python
cachedir: .cache
metadata: {'Platform': 'Darwin-16.5.0-x86_64-i386-64bit', 'Plugins': {'mozlog': '3.4', 'base-url': '1.3.0', 'metadata': '1.3.0', 'xdist': '1.15.0'}, 'Python': '2.7.10', 'Packages': {'py': '1.4.33', 'pluggy': '0.4.0', 'pytest': '3.0.7'}, 'Base URL': 'https://download.mozilla.org'}
baseurl: https://download.mozilla.org
rootdir: /Users/mbrandt/workspaces/go-bouncer/tests/e2e, inifile: tox.ini
plugins: xdist-1.15.0, metadata-1.3.0, base-url-1.3.0, mozlog-3.4
collected 537 items

tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[sha1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[esr-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[esr-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-sha] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.1esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[40.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[58.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[42.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[43.0.1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b8] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b8-ssl] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[100.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[cats] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[sha1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[esr-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[esr-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-sha] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.1esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[40.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[58.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[42.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[43.0.1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b8] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b8-ssl] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[100.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[cats] PASSED

-------------------------------- generated xml file: /Users/mbrandt/workspaces/go-bouncer/tests/e2e/results/py27.xml --------------------------------
=============================================================== 501 tests deselected ================================================================
==================================================== 36 passed, 501 deselected in 21.78 seconds =====================================================
flake8 installed: appdirs==1.4.3,configparser==3.5.0,enum34==1.1.6,flake8==3.3.0,mccabe==0.6.1,packaging==16.8,pycodestyle==2.3.1,pyflakes==1.5.0,pyparsing==2.2.0,six==1.10.0
flake8 runtests: PYTHONHASHSEED='3937497833'
flake8 runtests: commands[0] | flake8 --base-url=https://download.mozilla.org -k winxp
Usage: flake8 [options] file file ...

______________________________________________________________________ summary ______________________________________________________________________
  py27: commands succeeded
ERROR:   flake8: commands failed
➜  e2e git:(issue-122) ✗ tox --  -k winxp
py27 installed: apipkg==1.4,appdirs==1.4.3,asn1crypto==0.22.0,blessings==1.6,cffi==1.10.0,cryptography==1.8.1,enum34==1.1.6,execnet==1.4.1,idna==2.5,ipaddress==1.0.18,mozlog==3.4,packaging==16.8,py==1.4.33,pycparser==2.17,pyOpenSSL==16.2.0,pyparsing==2.2.0,pytest==3.0.7,pytest-base-url==1.3.0,pytest-metadata==1.3.0,pytest-xdist==1.15.0,requests==2.13.0,six==1.10.0
py27 runtests: PYTHONHASHSEED='1642410530'
py27 runtests: commands[0] | pytest --junit-xml=results/py27.xml --log-raw=results/py27_raw.txt --log-tbpl=results/py27_tbpl.txt -k winxp
================================================================ test session starts ================================================================
platform darwin -- Python 2.7.10, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /Users/mbrandt/workspaces/go-bouncer/tests/e2e/.tox/py27/bin/python
cachedir: .cache
metadata: {'Packages': {'pytest': '3.0.7', 'pluggy': '0.4.0', 'py': '1.4.33'}, 'Plugins': {'base-url': '1.3.0', 'xdist': '1.15.0', 'metadata': '1.3.0', 'mozlog': '3.4'}, 'Platform': 'Darwin-16.5.0-x86_64-i386-64bit', 'Python': '2.7.10', 'Base URL': 'http://bouncer-bouncer.stage.mozaws.net'}
baseurl: http://bouncer-bouncer.stage.mozaws.net
rootdir: /Users/mbrandt/workspaces/go-bouncer/tests/e2e, inifile: tox.ini
plugins: xdist-1.15.0, metadata-1.3.0, base-url-1.3.0, mozlog-3.4
collected 537 items

tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[sha1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[esr-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[esr-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-sha] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[beta-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[38.5.1esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[40.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[58.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[42.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[43.0.1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b8] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[49.0b8-ssl] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[100.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_1_redirects_to_correct_version[cats] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[sha1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[esr-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[esr-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-latest] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-sha] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[beta-stub] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[38.5.1esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[40.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[58.0.0esr] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[42.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[43.0.1] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b8] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[49.0b8-ssl] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[100.0] PASSED
tests/test_redirects.py::TestRedirects::test_ie6_winxp_useragent_5_2_redirects_to_correct_version[cats] PASSED

-------------------------------- generated xml file: /Users/mbrandt/workspaces/go-bouncer/tests/e2e/results/py27.xml --------------------------------
=============================================================== 501 tests deselected ================================================================
==================================================== 36 passed, 501 deselected in 22.08 seconds =====================================================
flake8 installed: appdirs==1.4.3,configparser==3.5.0,enum34==1.1.6,flake8==3.3.0,mccabe==0.6.1,packaging==16.8,pycodestyle==2.3.1,pyflakes==1.5.0,pyparsing==2.2.0,six==1.10.0
flake8 runtests: PYTHONHASHSEED='1642410530'
flake8 runtests: commands[0] | flake8 -k winxp
Usage: flake8 [options] file file ...
______________________________________________________________________ summary ______________________________________________________________________
  py27: commands succeeded