### PR TITLE
Add pyup config - update security related pkgs only

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,10 @@
+schedule: "every day"
+search: False
+update: insecure
+requirements:
+  - tests/e2e/requirements/tests.txt:
+      update: security
+      pin: True
+  - tests/e2e/requirements/flake8.txt
+      update: security
+      pin: True


### PR DESCRIPTION
In an effort to reduce the frequency with which pyup creates prs I've reduced it's scope to only submit prs for security related updates.

closes #138 