### PR TITLE
Bump shared-library version to 1.9

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent any
   libraries {
-    lib('fxtest@1.6')
+    lib('fxtest@1.9')
   }
   options {
     ansiColor('xterm')


### PR DESCRIPTION
Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/bouncer.adhoc/11/console