### PR TITLE
Renamed base.py to test_base.py

### DIFF
--- a/tests/e2e/tests/test_base.py
+++ b/tests/e2e/tests/test_base.py
@@ -58,17 +58,11 @@ class Base:
         response = self.request_with_headers(base_url, params=get_params)
         parsed_url = urlparse(response.url)
         # verify service is up and a 200 OK is returned
-        assert requests.codes.ok == response.status_code, \
-            'Redirect failed with HTTP status. %s' % \
-            self.response_info_failure_message(base_url, get_params, response)
+        assert requests.codes.ok == response.status_code
         # verify download location
-        assert parsed_url.netloc in self.cdn_netloc_locations, \
-            'Failed, redirected to unknown host. %s' % \
-            self.response_info_failure_message(base_url, get_params, response)
+        assert parsed_url.netloc in self.cdn_netloc_locations
         # verify Firefox package name and version
-        assert fx_pkg_name in response.url, \
-            'Failed: Expected product str did not match what was returned %s' % \
-            self.response_info_failure_message(base_url, get_params, response)
+        assert fx_pkg_name in response.url
 
     def request_with_headers(self, url, params, user_agent=_user_agent_firefox, locale='en-US'):
         """Make a request that includes 'user-agent', 'accept-language', and 'Connection: close' attributes in the

--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 
 from . import releng_utils as utils
-from .base import Base
+from .test_base import Base
 
 
 class TestRedirects(Base):

--- a/tests/e2e/tests/test_smoketests.py
+++ b/tests/e2e/tests/test_smoketests.py
@@ -5,7 +5,7 @@
 import pytest
 
 from . import releng_utils as utils
-from .base import Base
+from .test_base import Base
 
 
 class TestSmokeTests(Base):


### PR DESCRIPTION
This is so that pytest rewrites the assertions for improved failure messages.

Before:

```
        assert fx_pkg_name in response.url, \
            'Failed: Expected product str did not match what was returned %s' % \
>           self.response_info_failure_message(base_url, get_params, response)
E       AssertionError: Failed: Expected product str did not match what was returned Failed on http://bouncer-bouncer.stage.mozaws.net Using {'product': 'firefox-beta-latest', 'lang': 'en-US', 'os': 'win'}. Response URL: http://download.cdn.mozilla.net/pub/firefox/releases/58.0b8/win32/en-US/Firefox%20Setup%2058.0b8.exe Content-Type: application/x-msdos-programResponse Headers: Content-Length: 36371520Response Headers: x-amz-replication-status: COMPLETEDResponse Headers: Last-Modified: Thu, 30 Nov 2017 23:12:14 GMTResponse Headers: ETag: "c04755d57f6c23e561c98d675a69b2fd"Response Headers: x-amz-version-id: p9SADcCjI67Bszt3UuY87kP5yFMopc7NResponse Headers: Accept-Ranges: bytesResponse Headers: Server: AmazonS3Response Headers: X-Amz-Cf-Id: 6g8NSpGWMPVlL7Bkza2XisxL-IEB16s54N7ClskQUBxdJ-qtNVypFw==Response Headers: Date: Tue, 05 Dec 2017 17:38:50 GMTResponse Headers: Connection: close.
```

After:

```
>       assert fx_pkg_name in response.url, \
            self.response_info_failure_message(base_url, get_params, response)
E       AssertionError: Failed on http://bouncer-bouncer.stage.mozaws.net Using {'product': 'firefox-beta-latest', 'os': 'win', 'lang': 'en-US'}. Response URL: http://download.cdn.mozilla.net/pub/firefox/releases/58.0b8/win32/en-US/Firefox%20Setup%2058.0b8.exe Content-Type: application/x-msdos-programResponse Headers: Content-Length: 36371520Response Headers: x-amz-replication-status: COMPLETEDResponse Headers: Last-Modified: Thu, 30 Nov 2017 23:12:14 GMTResponse Headers: ETag: "c04755d57f6c23e561c98d675a69b2fd"Response Headers: x-amz-version-id: p9SADcCjI67Bszt3UuY87kP5yFMopc7NResponse Headers: Accept-Ranges: bytesResponse Headers: Server: AmazonS3Response Headers: X-Amz-Cf-Id: 6g8NSpGWMPVlL7Bkza2XisxL-IEB16s54N7ClskQUBxdJ-qtNVypFw==Response Headers: Date: Tue, 05 Dec 2017 17:39:33 GMTResponse Headers: Connection: close.
E       assert 'Firefox%20Setup%2058.0b9.exe' in 'http://download.cdn.mozilla.net/pub/firefox/releases/58.0b8/win32/en-US/Firefox%20Setup%2058.0b8.exe'
E        +  where 'http://download.cdn.mozilla.net/pub/firefox/releases/58.0b8/win32/en-US/Firefox%20Setup%2058.0b8.exe' = <Response [200]>.url
```

Note the two additional lines.