### PR TITLE
Limit locale versions to firefox_versions and parametrize them

### DIFF
--- a/tests/e2e/tests/releng_utils.py
+++ b/tests/e2e/tests/releng_utils.py
@@ -4,33 +4,6 @@
 
 import requests
 
-
-class FirefoxLocale:
-
-    def __init__(self, locale, version_info):
-        self.lang = locale
-        self.versions = self.parse_versions(version_info)
-
-    def parse_versions(self, version_info):
-        """Parses a dict and returns a list of Firefox versions,
-        ignoring Aurora and ESR builds.
-
-        :param version_info: {string:string} A dictionary with k,v of version and
-        os.
-
-        :returns: [string] A list of Firefox versions
-        """
-        versions = []
-        for version, os in version_info.items():
-            # remove all aurora builds and esr builds
-            if 'a' not in version and 'esr' not in version:
-                versions.append(version)
-        return versions
-
-    def __repr__(self):
-        return self.locale
-
-
 _product_details_url = 'https://product-details.mozilla.org/1.0/%s'  # mirror of ship-it, not behind vpn
 _ship_it_url = 'https://ship-it.mozilla.org/json/1.0/%s'  # behind vpn
 _firefox_primary_builds_uri = 'firefox_primary_builds.json'
@@ -113,18 +86,11 @@ def get_firefox_locales():
 
     Release Engineering maintains an up-to-date JSON file with the current
     Firefox release values - https://product-details.mozilla.org/1.0/firefox_primary_builds.json.
-
-    :returns list: [FirefoxLocale objects] a list of FirefoxLocale objects.
     """
-    locale_objs = []
     url = _product_details_url % _firefox_primary_builds_uri
     response = requests.get(url)
     response.raise_for_status()
-    locale_data = response.json()
-    for locale in locale_data:
-        versions = locale_data[locale]
-        locale_objs.append(FirefoxLocale(locale, versions))
-    return locale_objs
+    return response.json()
 
 
 def get_product_mappings(base_url=_product_details_url):

--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -83,25 +83,36 @@ class TestRedirects(Base):
             self.response_info_failure_message(base_url, param, response)
 
     @pytest.mark.parametrize('os', _os)
-    @pytest.mark.parametrize('locale', _locales, ids=lambda l: l.lang)
-    def test_verify_locales_redirect_to_the_expected_product(self, base_url, locale, os):
+    def test_verify_locales_redirect_to_the_expected_product(self, base_url, locale, os, version):
         """Verifies the downloaded version of Firefox matches the expected version number
         and filename when Firefox is requested for a specific OS and locale.
-
-        The test verifies the following aliases: firefox-latest, firefox-esr-latest,
-        firefox-nightly-latest, firefox-beta-latest, firefox-aurora-latest.
         """
-        lang = locale.lang
         # Ja locale has a macOS-specific locale
-        if lang == 'ja' and os == 'osx':
-            lang = 'ja-JP-mac'
+        if locale == 'ja' and os == 'osx':
+            locale = 'ja-JP-mac'
 
-        for version in locale.versions:
-            get_params = {
-                'product': 'firefox-' + version,
-                'lang': lang,
-                'os': os
-            }
+        get_params = {
+            'product': 'firefox-' + version,
+            'lang': locale,
+            'os': os
+        }
 
-            fx_pkg_name = self.get_expected_fx_pkg_str(os, 'latest', version)
-            self.verify_redirect_to_correct_product(base_url, fx_pkg_name, get_params)
+        fx_pkg_name = self.get_expected_fx_pkg_str(os, 'latest', version)
+        self.verify_redirect_to_correct_product(base_url, fx_pkg_name, get_params)
+
+
+def pytest_generate_tests(metafunc):
+    if 'locale' in metafunc.fixturenames:
+        argvalues = []
+
+        def valid_version(version):
+            # there are no builds for aurora locales
+            return 'a' not in version
+
+        locales = utils.get_firefox_locales()
+        _versions = filter(valid_version, utils.get_product_mappings().values())
+        for locale, versions in locales.items():
+            print(locale, versions, _versions)
+            for version in [v for v in versions if v in _versions]:
+                argvalues.append((locale, version))
+        metafunc.parametrize(['locale', 'version'], argvalues)


### PR DESCRIPTION
We've had failures for `test_verify_locales_redirect_to_the_expected_product` for the last 16 hours (since 17-Jan-2018 18:30:00) due to version 59.0b1 appearing in https://product-details.mozilla.org/1.0/firefox_primary_builds.json. Speaking to @pmac and @oremj in #stubby we should be safe to filter these by the versions specified in https://product-details.mozilla.org/1.0/firefox_versions.json. This is what I've done in this patch, but I've also made these versions test parameters, which improves reporting and running these tests in parallel.