### PR TITLE
Improve information provided in the event of a test failure

### DIFF
--- a/tests/e2e/setup.cfg
+++ b/tests/e2e/setup.cfg
@@ -6,7 +6,7 @@ default_section = THIRDPARTY
 known_first_party = tests
 
 [tool:pytest]
-addopts = -n=auto --verbose -r=a
+addopts = -n=auto --verbose -r=a --showlocals
 testpaths = tests
 xfail_strict = true
 base_url = http://bouncer-bouncer.stage.mozaws.net

--- a/tests/e2e/tests/test_base.py
+++ b/tests/e2e/tests/test_base.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from urllib import urlencode
 from urlparse import urlparse
 
 import requests
@@ -77,12 +76,7 @@ class Base:
         headers = {'user-agent': user_agent,
                    'accept-language': locale,
                    'Connection': 'close'}
-        try:
-            response = requests.head(url, headers=headers, verify=True, timeout=15, params=params, allow_redirects=True)
-        except requests.RequestException as e:
-            request_url = '%s/?%s' % (url, urlencode(params))
-            raise AssertionError('Failing URL: %s redirected to %s Error message: %s' % (request_url, response.url, e))
-        return response
+        return requests.head(url, headers=headers, verify=True, timeout=15, params=params, allow_redirects=True)
 
     def response_info_failure_message(self, url, param, response):
         """Generate a helpful error message that includes the server URL, GET params,


### PR DESCRIPTION
We had a couple of tests fail recently but there was a lack of details provided in the trace. This patch will show local variables (safe because we're not using any confidential values in this suite) on failure, and avoids an UnboundLocalError where we reference a variable that could not be assigned.