### PR TITLE
Use response URL when history is empty (no redirect occurs)

### DIFF
--- a/tests/e2e/tests/test_base.py
+++ b/tests/e2e/tests/test_base.py
@@ -55,7 +55,7 @@ class Base:
         :param get_params: The GET params to pass to Bouncer.
         """
         response = self.request_with_headers(base_url, params=get_params)
-        request_url = response.history[0].url
+        request_url = response.history[0].url if response.history else response.url
         parsed_url = urlparse(response.url)
         # verify service is up and a 200 OK is returned
         assert requests.codes.ok == response.status_code, request_url


### PR DESCRIPTION
We've seen a couple of failures when the response is not a 200 and no redirect occurs. This allows the assertion to fail rather than raising because the history is empty.