### PR TITLE
Poll for SCM changes every 5 minutes

### DIFF
--- a/tests/e2e/Jenkinsfile
+++ b/tests/e2e/Jenkinsfile
@@ -3,6 +3,9 @@ pipeline {
   libraries {
     lib('fxtest@1.10')
   }
+  triggers {
+    pollSCM('H/5 * * * *')
+  }
   options {
     ansiColor('xterm')
     timestamps()


### PR DESCRIPTION
@oremj @m8ttyB r?

I intentionally didn't add a cron trigger, because go-bouncer.prod and go-bouncer.stage are set to run at different intervals on https://qa-master.fxtest.jenkins.stage.mozaws.net/

This change, at least, makes sense for both jobs.

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/go-bouncer.adhoc/120/console