### PR TITLE
Fix path to combined requirements.txt, for pyup

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -2,9 +2,6 @@ schedule: "every day"
 search: False
 update: insecure
 requirements:
-  - tests/e2e/requirements/tests.txt:
-      update: security
-      pin: True
-  - tests/e2e/requirements/flake8.txt
+  - tests/e2e/requirements.txt:
       update: security
       pin: True


### PR DESCRIPTION
Passing ad-hoc job here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/go-bouncer.adhoc/139/console

Not sure the original ```flake8``` path worked, due to missing the missing ```:```, but that's unused now anyhow.

@oremj @m8ttyB @davehunt r?