### PR TITLE
Restore --skip-lock

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 
 COPY Pipfile pipenv.txt /src/
 RUN pip install -r pipenv.txt
-RUN pipenv install --system
+RUN pipenv install --system --skip-lock
 
 COPY . /src
 CMD pytest


### PR DESCRIPTION
@davehunt @oremj @m8ttyB r?

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/go-bouncer.adhoc/153/console

If we don't skip the lockfile, we either end up with errors (in recent pipenv versions), or we do redundant work, since we don't use the Pipfile.lock (due to it not being updated fully by @pyup-bot yet).