### PR TITLE
Quell pip-version upgrade warning

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --update gcc libffi-dev musl-dev openssl-dev python-dev
 WORKDIR /src
 
 COPY Pipfile pipenv.txt /src/
-RUN pip install -r pipenv.txt
+RUN pip install --disable-pip-version-check -r pipenv.txt
 RUN pipenv install --system --skip-lock
 
 COPY . /src


### PR DESCRIPTION
@davehunt @oremj @m8ttyB 

This quells the red warning/nagging text[0]:

```
17:01:00 You are using pip version 9.0.1, however version 9.0.2 is available.
17:01:00 You should consider upgrading via the 'pip install --upgrade pip' command.
```

Ad-hoc build here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/go-bouncer.adhoc/164/consoleFull

[0] https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/go-bouncer.adhoc/163/consoleFull