### PR TITLE
Get all dependency updates, each Monday

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,6 +1,5 @@
 schedule: "every week on monday"
 search: False
 requirements:
-  - tests/e2e/Pipfile:
-      pin: True
+  - tests/e2e/Pipfile
   - tests/e2e/pipenv.txt

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,8 +1,6 @@
-schedule: "every day"
+schedule: "every week on monday"
 search: False
-update: insecure
 requirements:
   - tests/e2e/Pipfile:
-      update: security
       pin: True
   - tests/e2e/pipenv.txt


### PR DESCRIPTION
My rationale for this change: not all security/stability updates are denoted as such (at least, not to PyPI, etc.).  A weekly batch, on Monday, is easier to deal with (IMHO), and should give us enough time (rest of the week) if we need/want to revert, for any reason.

@m8ttyB @davehunt @oremj r?