### PR TITLE
Upgrade pytest-html to 1.18.0

### DIFF
--- a/tests/e2e/Pipfile
+++ b/tests/e2e/Pipfile
@@ -16,7 +16,7 @@ flake8-isort = "==2.5"
 mozlog = "==3.7"
 pytest = "==3.5.1"
 pytest-base-url = "==1.4.1"
-pytest-html = "==1.17.0"
+pytest-html = "==1.18.0"
 pytest-xdist = "==1.22.2"
 
 


### PR DESCRIPTION
As the title goes...

Passing ad-hoc here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/go-bouncer.adhoc/184/console

@davehunt @mozilla-services/firefox-test-engineering r?