### PR TITLE
pin winxp builds to 52.9.0 esr builds

### DIFF
--- a/tests/e2e/tests/test_redirects.py
+++ b/tests/e2e/tests/test_redirects.py
@@ -16,7 +16,7 @@ class TestRedirects(Base):
 
     _locales = utils.get_firefox_locales()
     _os = ('win', 'win64', 'linux', 'linux64', 'osx')
-    _winxp_esr_version = utils.get_version_info_for_alias('firefox-esr-latest')
+    _winxp_esr_version = '52.9.0esr.exe'
     _winxp_products = [
         'stub',
         'latest',


### PR DESCRIPTION
winxp (and vista) have been pinned to receive `52.9.0 esr` as part of the deprecation process. See  https://bugzilla.mozilla.org/show_bug.cgi?id=1319164 for additional information.

closes #253 