### PR TITLE
Update flake8-isort to latest, version 2.6.0

### DIFF
--- a/tests/e2e/Pipfile
+++ b/tests/e2e/Pipfile
@@ -12,7 +12,7 @@ name = "pypi"
 [packages]
 
 flake8 = "==3.6.0"
-flake8-isort = "==2.5"
+flake8-isort = "==2.6.0"
 mozlog = "==3.9"
 pytest = "==3.10.1"
 pytest-base-url = "==1.4.1"


### PR DESCRIPTION
There's a bit too much in https://github.com/mozilla-services/go-bouncer/pull/275, so just trying to unfurl + separate PRs.

@oremj @m8ttyB r?