### PR TITLE
Update pytest-html to 1.20.0

### DIFF
--- a/tests/e2e/Pipfile
+++ b/tests/e2e/Pipfile
@@ -16,7 +16,7 @@ flake8-isort = "==2.6.0"
 mozlog = "==3.10"
 pytest = "==4.1.1"
 pytest-base-url = "==1.4.1"
-pytest-html = "==1.19.0"
+pytest-html = "==1.20.0"
 pytest-xdist = "==1.25.0"
 
 


### PR DESCRIPTION
Sorry, ignore the branch name.

With this and https://github.com/mozilla-services/go-bouncer/pull/284, we can hopefully close out https://github.com/mozilla-services/go-bouncer/pull/281.