### PR TITLE
Use Go 1.20 Debian Bullseye for old Docker compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20-bullseye
 
 ENV PROJECT=github.com/mozilla-services/go-bouncer
 


### PR DESCRIPTION
fixes https://github.com/mozilla-services/go-bouncer/issues/374