### PR TITLE
Rename pinned firefox nightly installer product to firefox-nightly-pr…

### DIFF
--- a/fixtures/data.sql
+++ b/fixtures/data.sql
@@ -301,8 +301,8 @@ INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`
 INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-nightly-latest',1,1,1,5,0);
 INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-nightly-latest-l10n-SSL',1,1,1,6,1);
 INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-nightly-latest-l10n',1,1,1,7,0);
-INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-127.0a1-SSL',1,1,1,8,1);
-INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-127.0a1',1,1,1,9,0);
+INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-nightly-pre2024-SSL',1,1,1,8,1);
+INSERT INTO `mirror_products` (`count`, `name`, `checknow`, `priority`, `active`, `id`, `ssl_only`) VALUES (0,'Firefox-nightly-pre2024',1,1,1,9,0);
 /*!40000 ALTER TABLE `mirror_products` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/handlers.go
+++ b/handlers.go
@@ -22,7 +22,7 @@ const (
 	DefaultLang               = "en-US"
 	DefaultOS                 = "win"
 	firefoxSHA1ESRAliasSuffix = "sha1"
-	fxPre2024LastNightly      = "firefox-127.0a1"
+	fxPre2024LastNightly      = "firefox-nightly-pre2024"
 )
 
 type xpRelease struct {


### PR DESCRIPTION
…e2024

The certificate rotation for nightly was delayed so calling it firefox-127.0a1 now would be confusing.