### PR TITLE
Revert "Switch back to regular golang 1.20 docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20-bullseye
 
 ENV PROJECT=github.com/mozilla-services/go-bouncer
 


### PR DESCRIPTION
Reverts mozilla-services/go-bouncer#382

This is causing failures on stage, similar to what was described in #374.