### PR TITLE
No bug - Add optional config to run bouncer-admin locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ scripts/
 **/*_test.go
 README.md
 compose.yaml
+compose-admin.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,32 +1,5 @@
-# Compiled Object files, Static and Dynamic libs (Shared Objects)
-*.o
-*.a
-*.so
-*.pyc
-
-# Folders
-__pycache__
-_obj
-_test
-.cache
-.tox
-
-# Architecture specific extensions/prefixes
-*.[568vq]
-[568vq].out
-
-*.cgo1.go
-*.cgo2.c
-_cgo_defun.c
-_cgo_gotypes.go
-_cgo_export.*
-
-_testmain.go
-
-*.exe
-*.test
-*.prof
-
-/go-bouncer
-/go-sentry/go-sentry
+# This should be a directory, or a symlink so that why the trailing slash is
+# omitted.
+/bouncer-admin
 /coverage.txt
+/go-bouncer

--- a/README.md
+++ b/README.md
@@ -41,6 +41,37 @@ the following headers:
 - `x-debug-cache-key`: the computed cache key
 - `x-debug-referer`: the referer value, if any
 
+### Setting up `bouncer-admin` in localdev
+
+[bouncer-admin][] is the admin interface for go-bouncer. It can be optionally
+set up by first cloning the repository (once):
+
+```
+git clone https://github.com/mozilla-services/bouncer-admin
+```
+
+Then, run `docker compose` as follows:
+
+```
+docker compose -f compose.yaml -f compose-admin.yaml up -d
+```
+
+Note: Every `docker compose` needs to specify both configuration files if the
+intent is to interact with the `admin` container, e.g. `docker compose -f
+compose.yaml -f compose-admin.yaml logs -f admin`.
+
+The API is available at: http://127.0.0.1:9000/api/. The authenticated user is
+`admin` with the traditional `admin` password. Here is an example to create a
+new product:
+
+```
+curl -X POST 'http://admin:admin@127.0.0.1:9000/api/product_add/' -d 'product=A-Test-Product&ssl_only=true'
+<?xml version="1.0" encoding="utf-8"?>
+<products>
+  <product id="4557" name="A-Test-Product"/>
+</products>
+```
+
 ## Environment variables
 
 ### `BOUNCER_ADDR`
@@ -76,3 +107,4 @@ BOUNCER_STUB_ROOT_URL?product=PRODUCT&os=OS&lang=LANG&attribution_sig=ATTRIBUTIO
 ```
 
 [go-bouncer]: https://github.com/mozilla-services/go-bouncer/
+[bouncer-admin]: https://github.com/mozilla-services/bouncer-admin/

--- a/compose-admin.yaml
+++ b/compose-admin.yaml
@@ -1,0 +1,17 @@
+services:
+  admin:
+    build:
+      context: ./bouncer-admin/
+    ports:
+      - 9000:8000
+    environment:
+      DATABASE_URL: mysql
+      DB_USER: bounceruser
+      DB_PASS: bouncerpass
+      DB_NAME: bouncerdb
+      AUTH_USERS: '{"admin": "admin"}'
+      # This is (mainly) used to get stacktraces in the container logs.
+      FLASK_ENV: development
+    depends_on:
+      mysql:
+        condition: service_healthy


### PR DESCRIPTION
~~Depends on https://github.com/mozilla-services/bouncer-admin/pull/142~~

That might be useful, right? Riiight?